### PR TITLE
Update README.md with links to Telegram notification setup

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -96,6 +96,7 @@ Full list of options is available by `--help` command
 - [Create a botnet of 30+ free and standalone Linux servers](https://auto-ddos.notion.site/dd91326ed30140208383ffedd0f13e5c)
 - [Analysis of mhddos_proxy](https://telegra.ph/Anal%D1%96z-zasobu-mhddos-proxy-04-01)
 - [VPN](https://auto-ddos.notion.site/VPN-5e45e0aadccc449e83fea45d56385b54)
+- [Setting up with notification to Telegram](https://github.com/sadviq99/mhddos_proxy-setup)
 
 ### ✪ Custom proxies
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
 - [Створення ботнету з 20+ безкоштовних серверів](https://auto-ddos.notion.site/dd91326ed30140208383ffedd0f13e5c)
 - [Аналіз засобу mhddos_proxy](https://telegra.ph/Anal%D1%96z-zasobu-mhddos-proxy-04-01)
 - [VPN](https://auto-ddos.notion.site/VPN-5e45e0aadccc449e83fea45d56385b54)
+- [Налаштування з нотифікаціями у Телеграм](https://github.com/sadviq99/mhddos_proxy-setup)
 
 ### ✪ Власні проксі
 


### PR DESCRIPTION
Update the README.md files with the link that instructs the users on how to run mhddos_proxy in Docker and send attacks statistic to Telegram. This is handy since users don't need to log in to VPS each time in order to make sure that everything is working fine.

Those links were already mentioned in the old [README.md](https://github.com/porthole-ascend-cinnamon/mhddos_proxy/blob/main/README.md#5--%D0%BA%D0%BE%D0%BC%D1%8C%D1%8E%D0%BD%D1%96%D1%82%D1%96) file but were not included into the new version. I'm working hard to maintain those scripts updated according to the latest mhddos_proxy changes, I see users' demand on this, and I would appreciate it if it could be included in the new README.md file as well. 

<img width="275" alt="image" src="https://user-images.githubusercontent.com/102911721/178362907-821975b6-1f8d-4281-9a63-1483540bb861.png">
