### PR TITLE
Instructions for Macos

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -53,6 +53,26 @@ sysctl -w net.ipv4.ip_local_port_range="16384 65535"
 3. Next, run `chmod +x mhddos_proxy_mac && sudo xattr -d com.apple.quarantine mhddos_proxy_mac` (you'll need to enter your password)
 4. To start the attack, run `./mhddos_proxy_mac`
 
+#### Special considerations while running application under macOS
+
+Running application under macOS, you may face system restriction, that looks like that
+```
+The total number of threads has been reduced to 206 due to the limitations of your system
+```
+
+In order to increase the number of allowed file handles, and number of threads, 
+you should use the following commands from the root directory of a project:
+(all commands under `sudo`)
+```
+sysctl -w kern.maxfiles=65536
+sysctl -w kern.maxfilesperproc=65536
+cp darwin/limit.maxfiles.plist /Library/LaunchDaemons
+chown root:wheel /Library/LaunchDaemons/limit.maxfiles.plist
+launchctl load -w /Library/LaunchDaemons/limit.maxfiles.plist
+launchctl limit maxfiles
+```
+and restart the system. After that, limitations will be removed.
+
 #### Docker
 
 1. Install and launch [Docker](https://docs.docker.com/desktop/#download-and-install)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,26 @@ sysctl -w net.ipv4.ip_local_port_range="16384 65535"
 3. Виконайте `chmod +x mhddos_proxy_mac && sudo xattr -d com.apple.quarantine mhddos_proxy_mac` (потрібно буде ввести пароль)
 4. Для початку атаки, виконуйте `./mhddos_proxy_mac`
 
+#### Особливості запуску прiложення під Mac
+
+Запускаючи програму під macOS, ви можете зіткнутися з наступним попередженням
+```
+Загальну кількість потоків зменшено до 206 через обмеження вашої системи
+```
+
+Щоб збільшити кількість дозволених відкритих файлів та потоків програми, 
+вам потрібно виконати наступні команди з кореневого каталогу проекту 
+(усі команди виконувати під `sudo`)
+```
+sysctl -w kern.maxfiles=65536
+sysctl -w kern.maxfilesperproc=65536
+cp darwin/limit.maxfiles.plist /Library/LaunchDaemons
+chown root:wheel /Library/LaunchDaemons/limit.maxfiles.plist
+launchctl load -w /Library/LaunchDaemons/limit.maxfiles.plist
+launchctl limit maxfiles
+```
+та перезапустити систему. Після цього всі обмеження мають бути зняті.
+
 #### Docker
 
 1. Встановіть та запустіть [Docker](https://docs.docker.com/desktop/#download-and-install)

--- a/darwin/limit.maxfiles.plist
+++ b/darwin/limit.maxfiles.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>  
+  <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"  
+          "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+  <plist version="1.0">  
+    <dict>
+      <key>Label</key>
+      <string>limit.maxfiles</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>launchctl</string>
+        <string>limit</string>
+        <string>maxfiles</string>
+        <string>64000</string>
+        <string>524288</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>ServiceIPC</key>
+      <false/>
+    </dict>
+  </plist> 


### PR DESCRIPTION
I put the system-level config in `darwin/limit.maxfiles.plist`, so that not to confuse inexperienced users to create and editing files in the system directory. You can rename this directory, or change the way config is installed any way you like